### PR TITLE
Add Touch file helper

### DIFF
--- a/Cake.FileHelpers/FileHelpers.cs
+++ b/Cake.FileHelpers/FileHelpers.cs
@@ -102,6 +102,19 @@ namespace Cake.FileHelpers
         }
 
         /// <summary>
+        /// Sets the last write time of a file to the current time
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="file">The file to touch</param>
+        [CakeMethodAlias]
+        public static void FileTouch(this ICakeContext context, FilePath file)
+        {
+            var filename = file.MakeAbsolute(context.Environment).FullPath;
+
+            File.SetLastWriteTimeUtc(filename, DateTime.UtcNow);
+        }
+
+        /// <summary>
         /// Replaces the text in files matched by the given globber pattern
         /// </summary>
         /// <returns>The files that had text replaced in them.</returns>


### PR DESCRIPTION
This allows you to 'touch' a file in a Cake script, setting the last write time of the file to the current time.

As discussed in https://github.com/cake-build/cake/issues/1479 .

I was going to add a test, but... I can't think of a way to test this reasonably without introducing a `System.IO.File` mock or something. I figured calling `System.IO.File.SetLastWriteTimeUtc` directly from the test wouldn't make for a very useful test.